### PR TITLE
Bring database url configuration to top level

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,10 @@ class Test {
   value = new IntegerColumn();
 }
 
-export const db = createDatabase({
+// Example value: `postgres://postgres@localhost/test`
+const dbName = process.env.DATABASE_URL
+
+export const db = createDatabase(dbName, {
   test: new Test(),
 });
 

--- a/examples/db.ts
+++ b/examples/db.ts
@@ -7,7 +7,9 @@ export class Test {
   value = new IntegerColumn();
 }
 
-export const db = createDatabase({
+const dbName = process.env.DATABASE_URL || 'postgres://postgres@localhost/test'
+
+export const db = createDatabase(dbName, {
   test: new Test(),
 });
 

--- a/src/__tests__/query.test.ts
+++ b/src/__tests__/query.test.ts
@@ -46,7 +46,7 @@ class Bar {
   val = new TextColumn().notNull();
 }
 
-const db = createDatabase({
+const db = createDatabase(process.env.DATABASE_URL!, {
   account: new Account(),
   test: new Test(),
   foo: new Foo(),

--- a/src/database/pool.ts
+++ b/src/database/pool.ts
@@ -43,14 +43,10 @@ export class PoolDatabase<Tables extends TableMap> extends Database<Tables> {
     return new pg.Pool(config as any);
   }
 
-  constructor(tables: Tables) {
+  constructor(databaseUrl: string, tables: Tables) {
     super(tables);
 
-    if (!process.env.DATABASE_URL) {
-      throw new Error(`DATABASE_URL is not set.`);
-    }
-
-    this.databaseUrl = String(process.env.DATABASE_URL);
+    this.databaseUrl = databaseUrl;
     this.pool = this.createPool({
       min: process.env.DB_MIN_POOL_SIZE ? parseInt(process.env.DB_MIN_POOL_SIZE!, 10) : undefined,
       max: process.env.DB_MAX_POOL_SIZE ? parseInt(process.env.DB_MAX_POOL_SIZE!, 10) : undefined,
@@ -247,8 +243,9 @@ export const createDatabase = <
       }
   }
 >(
+  databaseUrl: string,
   tables: Tables,
 ): State & PoolDatabase<Tables> => {
-  const database = new PoolDatabase(tables);
+  const database = new PoolDatabase(databaseUrl, tables);
   return extendDatabase<State, Tables, PoolDatabase<Tables>>(tables, database);
 };

--- a/src/sql-generator/__tests__/table.test.ts
+++ b/src/sql-generator/__tests__/table.test.ts
@@ -24,7 +24,7 @@ import { Table } from '../../table';
 import { generateSql } from '../table';
 
 const test = (clazz: any) => {
-  const db = createDatabase({
+  const db = createDatabase(process.env.DATABASE_URL!, {
     test: clazz,
   });
 
@@ -121,7 +121,7 @@ describe('generate sql', () => {
       id = new UuidColumn().primaryKey().notNull();
     }
 
-    const db = createDatabase({
+    const db = createDatabase(process.env.DATABASE_URL!, {
       foo: new Foo(),
       bar: new Bar(),
     });
@@ -150,7 +150,7 @@ describe('generate sql', () => {
       id = new UuidColumn().primaryKey().notNull();
     }
 
-    const db = createDatabase({
+    const db = createDatabase(process.env.DATABASE_URL!, {
       foo: new Foo(),
       bar: new Bar(),
     });
@@ -179,7 +179,7 @@ describe('generate sql', () => {
       id = new UuidColumn().primaryKey().notNull();
     }
 
-    const db = createDatabase({
+    const db = createDatabase(process.env.DATABASE_URL!, {
       foo: new Foo(),
       bar: new Bar(),
     });
@@ -208,7 +208,7 @@ describe('generate sql', () => {
       id = new UuidColumn().primaryKey().notNull();
     }
 
-    const db = createDatabase({
+    const db = createDatabase(process.env.DATABASE_URL!, {
       foo: new Foo(),
       bar: new Bar(),
     });
@@ -237,7 +237,7 @@ describe('generate sql', () => {
       id = new UuidColumn().primaryKey().notNull();
     }
 
-    const db = createDatabase({
+    const db = createDatabase(process.env.DATABASE_URL!, {
       foo: new Foo(),
       bar: new Bar(),
     });


### PR DESCRIPTION
This change removes one dependency on `process.env`. Useful to me because my framework already has a system for managing environment configuration.