### PR TITLE
Add case statement

### DIFF
--- a/src/__checks__/__snapshots__/select.check.ts.snap
+++ b/src/__checks__/__snapshots__/select.check.ts.snap
@@ -25,6 +25,8 @@ exports[`select should select and await result set (type) should match snapshot 
 
 exports[`select should select array_agg (type) should match snapshot 1`] = `"{ arrayAgg: GetDataType<string[], false>; }"`;
 
+exports[`select should select case with correct type and alias (type) should match snapshot 1`] = `"{ bar: GetDataType<\\"A\\" | \\"B\\" | \\"C\\", true>; }"`;
+
 exports[`select should select expression (type) should match snapshot 1`] = `"{ \\"?column?\\": GetDataType<number, false>; }"`;
 
 exports[`select should select named expression (type) should match snapshot 1`] = `"{ test: GetDataType<number, false>; }"`;

--- a/src/__checks__/select.check.ts
+++ b/src/__checks__/select.check.ts
@@ -83,6 +83,21 @@ const db = defineDb({ foo, bar }, () => Promise.resolve({ rows: [], affectedCoun
       .where(db.foo.id.in(db.select(db.foo.createDate).from(db.foo))),
   );
 
+  // @dts-jest:snap should select case with correct type and alias
+  toSnap(
+    db.select(
+      db
+        .case()
+        .when(db.foo.value.gt(100))
+        .then('A' as const)
+        .when(db.foo.value.gt(0))
+        .then('B' as const)
+        .else('C' as const)
+        .end()
+        .as(`bar`),
+    ).from(db.foo),
+  );
+
   db.select(db.foo.id, db.foo.value)
     .from(db.foo)
     .then((result) => {

--- a/src/__tests__/select.test.ts
+++ b/src/__tests__/select.test.ts
@@ -714,5 +714,32 @@ describe(`select`, () => {
 
   it(`should select list item boolean`, () => {
     const query = db.select(db.listItem.id).from(db.listItem).where(db.listItem.isGreat);
+
+    expect(toSnap(query)).toMatchInlineSnapshot(`
+      Object {
+        "parameters": Array [],
+        "text": "SELECT list_item.id FROM list_item WHERE list_item.is_great",
+      }
+    `);
+  });
+
+  it(`should select with case and else`, () => {
+    const query = db
+      .select(
+        db.foo.id,
+        db.case().when(db.foo.value.gt(0)).then('great').else('not great').end().as('greatness'),
+      )
+      .from(db.foo);
+
+    expect(toSnap(query)).toMatchInlineSnapshot(`
+      Object {
+        "parameters": Array [
+          0,
+          "great",
+          "not great",
+        ],
+        "text": "SELECT foo.id, (WHEN foo.value > $1 THEN $2 ELSE $3) \\"greatness\\" FROM foo",
+      }
+    `);
   });
 });

--- a/src/case.ts
+++ b/src/case.ts
@@ -1,0 +1,35 @@
+import { BooleanQuery, Query } from './query';
+import { ParameterToken, StringToken, Token } from './tokens';
+
+import { Expression } from './expression';
+
+export class CaseStatement<DataType> {
+  constructor(private readonly tokens: Token[]) {}
+
+  when<Q extends Query<any>>(expression: Expression<boolean, boolean, string> | BooleanQuery<Q>) {
+    const self = this;
+    return {
+      then<T>(result: T) {
+        return new CaseStatement<DataType | T>([
+          ...self.tokens,
+          new StringToken(`WHEN`),
+          ...expression.toTokens(),
+          new StringToken(`THEN`),
+          new ParameterToken(result),
+        ]);
+      },
+    };
+  }
+
+  else<T>(result: T) {
+    return new CaseStatement<DataType | T>([
+      ...this.tokens,
+      new StringToken(`ELSE`),
+      new ParameterToken(result),
+    ]);
+  }
+
+  end(): Expression<DataType, true, 'case'> {
+    return new Expression(this.tokens, `case`);
+  }
+}

--- a/src/db.ts
+++ b/src/db.ts
@@ -8,6 +8,8 @@ import { makeDeleteFrom } from './delete';
 import { makeUpdate } from './update';
 import { makeWith } from './with';
 import { toSnakeCase } from './naming/snake-case';
+import * as sqlFunctions from './sql-functions';
+import { CaseStatement } from './case';
 
 const createTables = <TableDefinitions extends { [key: string]: TableDefinition<any> }>(
   tableDefinitions: TableDefinitions,
@@ -57,6 +59,8 @@ export const defineDb = <TableDefinitions extends { [key: string]: TableDefiniti
     deleteFrom: makeDeleteFrom(queryExecutor),
     update: makeUpdate(queryExecutor),
     with: makeWith(queryExecutor),
+    case: () => new CaseStatement<never>([]),
+    ...sqlFunctions,
 
     ...createTables(tableDefinitions),
   };


### PR DESCRIPTION
This allows you to do something like the below—all while retaining the type of the return value (in this case `bar: ‘A’ | ‘B’ | ‘C’`).

```ts
db.select(
      db
        .case()
          .when(db.foo.value.gt(100)).then('A' as const)
          .when(db.foo.value.gt(0)).then('B' as const)
          .else('C' as const)
        .end()
      .as(`bar`),
).from(db.foo)
```

This also moves all sql functions in the db instance which makes sense to avoid issues with reserved keywords (such as case).