### PR TITLE
Update README.md to include the build script to pass all tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ This is a list of all the data types and it's companioning data type function.
 
 ## Contribute
 
-Once you clone the repo, do a `npm install` you should be able to run `npm test` seeing everything turn green. Feel free to pick up one of the open issues — in particular you can pick up one labeled with "good first issue". Be sure to claim the issue before you start so we avoid two or more people working on the same thing.
+Once you clone the repo, do a `npm install` + `npm run build`. Now you should be able to run `npm test` seeing everything turn green. Feel free to pick up one of the open issues — in particular you can pick up one labeled with "good first issue". Be sure to claim the issue before you start so we avoid two or more people working on the same thing.
 
 ---
 


### PR DESCRIPTION
I noticed when I forked and cloned the tests for the checks under __tests__ weren't passing without a build being ran. Here's a update for the README reflecting a change to add `npm run build` as a step