### PR TITLE
Bug with optional parameters in column definitions

### DIFF
--- a/workspaces/mammoth/src/data-types.ts
+++ b/workspaces/mammoth/src/data-types.ts
@@ -1,7 +1,9 @@
 import { ColumnDefinition, makeColumnDefinition } from './column';
 
-const variableLength = (string: string, ...n: (number | undefined)[]) =>
-  n.length > 0 ? `${string}(${n.join(`, `)})` : string;
+const variableLength = (string: string, ...n: (number | undefined)[]) => {
+  const pruned = n.filter((i) => i != undefined);
+  return pruned.length > 0 ? `${string}(${pruned.join(`, `)})` : string;
+};
 
 const makeDataType = makeColumnDefinition;
 


### PR DESCRIPTION
If you define a table as character but don't pass in a `n` length, then undefined is passed. This is further passed  to `variableLength` function as `[ undefined ]` (array with 1 undefined member) which throws a `Error: syntax error at or near ")"` when trying to generate migrations.

Steps to replicate:
1. Add a column like so `content: character()` to a table
2. Run `mammoth next`.